### PR TITLE
Fix grasp planning example documentation that omits required argument flag

### DIFF
--- a/docs/source/tutorials/planning.rst
+++ b/docs/source/tutorials/planning.rst
@@ -25,7 +25,7 @@ Run the Example Python Script
 -----------------------------
 From a new terminal run the following out of the root of your `gqcnn` repo::
 
-	python examples/policy.py /path/to/your/policy/configuration
+	python examples/policy.py --config-filename /path/to/your/policy/configuration
 
 You should see a sequence of images similar to these:
                         


### PR DESCRIPTION
https://github.com/BerkeleyAutomation/gqcnn/blob/master/examples/policy.py#L25

In my environment running as the current documentation says didn't work, and I needed the argument flag declared here.