### PR TITLE
Generate new policy directory name w/ experiment id

### DIFF
--- a/gqcnn/policy.py
+++ b/gqcnn/policy.py
@@ -243,7 +243,7 @@ class GraspingPolicy(Policy):
             self._policy_dir = os.path.join(self._logging_dir, 'policy_output_%s' %(policy_id))
             while os.path.exists(self._policy_dir):
                 policy_id = utils.gen_experiment_id()
-            self._policy_dir = os.path.join(self._logging_dir, 'policy_output_%s' %(policy_id))
+                self._policy_dir = os.path.join(self._logging_dir, 'policy_output_%s' %(policy_id))
             os.mkdir(self._policy_dir)
             state_dir = os.path.join(self._policy_dir, 'state')
             state.save(state_dir)

--- a/gqcnn/policy.py
+++ b/gqcnn/policy.py
@@ -240,10 +240,10 @@ class GraspingPolicy(Policy):
         # save state
         if self._logging_dir is not None:
             policy_id = utils.gen_experiment_id()
-            policy_dir = os.path.join(self._logging_dir, 'policy_output_%s' %(policy_id))
+            policy_dir = os.path.join(self._logging_dir, 'policy_output_%s' % (policy_id))
             while os.path.exists(policy_dir):
                 policy_id = utils.gen_experiment_id()
-                policy_dir = os.path.join(self._logging_dir, 'policy_output_%s' %(policy_id))
+                policy_dir = os.path.join(self._logging_dir, 'policy_output_%s' % (policy_id))
             self._policy_dir = policy_dir
             os.mkdir(self._policy_dir)
             state_dir = os.path.join(self._policy_dir, 'state')

--- a/gqcnn/policy.py
+++ b/gqcnn/policy.py
@@ -240,10 +240,11 @@ class GraspingPolicy(Policy):
         # save state
         if self._logging_dir is not None:
             policy_id = utils.gen_experiment_id()
-            self._policy_dir = os.path.join(self._logging_dir, 'policy_output_%s' %(policy_id))
-            while os.path.exists(self._policy_dir):
+            policy_dir = os.path.join(self._logging_dir, 'policy_output_%s' %(policy_id))
+            while os.path.exists(policy_dir):
                 policy_id = utils.gen_experiment_id()
-                self._policy_dir = os.path.join(self._logging_dir, 'policy_output_%s' %(policy_id))
+                policy_dir = os.path.join(self._logging_dir, 'policy_output_%s' %(policy_id))
+            self._policy_dir = policy_dir
             os.mkdir(self._policy_dir)
             state_dir = os.path.join(self._policy_dir, 'state')
             state.save(state_dir)


### PR DESCRIPTION
When running repeated evaluations of the same policy class, I noticed that we will occasionally infinite loop here because the policy directory already exists, but we aren't updating the policy directory path in the loop so the loop condition never changes and we never exit.

Fix: when we generate a new experiment id in the loop, also update the policy dir so that the loop condition will change.

One question I have is: why in successive calls to the policy are we generating the same initial experiment id. Seems like the odds of this happening are very low, so I suspect there may be some issue with seeding the randomness of the experiment id when running as a webservice.