### PR TITLE
Fixing worker random seeds and cleaning up debugging

### DIFF
--- a/cfg/finetune.yaml
+++ b/cfg/finetune.yaml
@@ -56,9 +56,9 @@ gaussian_process_sigma: 0.005
 tensorboard_port: 6006
 
 # debugging params
-debug: 0
-debug_num_files: 1000000000
-seed: 24098
+debug: &debug 0
+debug_num_files: 10 # speeds up initialization
+seed: &seed 24098
 
 ### GQCNN CONFIG ###
 gqcnn:
@@ -66,8 +66,8 @@ gqcnn:
   im_height: 96
   im_width: 96
   im_channels: 1
-  debug: 0
-  seed: 24098
+  debug: *debug
+  seed: *seed
 
   # needs to match input data mode that was used for training, determines the pose dimensions for the network
   gripper_mode: parallel_jaw

--- a/cfg/finetune_dex-net_4.0_pj.yaml
+++ b/cfg/finetune_dex-net_4.0_pj.yaml
@@ -56,9 +56,9 @@ gaussian_process_sigma: 0.005
 tensorboard_port: 6006
 
 # debugging params
-debug: 0
-debug_num_files: 1000000000
-seed: 24098
+debug: &debug 0
+debug_num_files: 10 # speeds up initialization
+seed: &seed 24098
 
 ### GQCNN CONFIG ###
 gqcnn:
@@ -66,8 +66,8 @@ gqcnn:
   im_height: 96
   im_width: 96
   im_channels: 1
-  debug: 0
-  seed: 24098
+  debug: *debug
+  seed: *seed
 
   # needs to match input data mode that was used for training, determines the pose dimensions for the network
   gripper_mode: parallel_jaw

--- a/cfg/finetune_dex-net_4.0_suction.yaml
+++ b/cfg/finetune_dex-net_4.0_suction.yaml
@@ -56,9 +56,9 @@ gaussian_process_sigma: 0.005
 tensorboard_port: 6006
 
 # debugging params
-debug: 0
-debug_num_files: 1000000000
-seed: 24098
+debug: &debug 0
+debug_num_files: 10 # speeds up initialization
+seed: &seed 24098
 
 ### GQCNN CONFIG ###
 gqcnn:
@@ -66,8 +66,8 @@ gqcnn:
   im_height: 96
   im_width: 96
   im_channels: 1
-  debug: 0
-  seed: 24098
+  debug: *debug
+  seed: *seed
 
   # needs to match input data mode that was used for training, determines the pose dimensions for the network
   gripper_mode: suction

--- a/cfg/finetune_example_pj.yaml
+++ b/cfg/finetune_example_pj.yaml
@@ -56,9 +56,9 @@ gaussian_process_sigma: 0.005
 tensorboard_port: 6006
 
 # debugging params
-debug: 0
-debug_num_files: 1000000000
-seed: 24098
+debug: &debug 0
+debug_num_files: 10 # speeds up initialization
+seed: &seed 24098
 
 ### GQCNN CONFIG ###
 gqcnn:
@@ -66,8 +66,8 @@ gqcnn:
   im_height: 96
   im_width: 96
   im_channels: 1
-  debug: 0
-  seed: 24098
+  debug: *debug
+  seed: *seed
 
   # needs to match input data mode that was used for training, determines the pose dimensions for the network
   gripper_mode: parallel_jaw

--- a/cfg/finetune_example_suction.yaml
+++ b/cfg/finetune_example_suction.yaml
@@ -56,9 +56,9 @@ gaussian_process_sigma: 0.005
 tensorboard_port: 6006
 
 # debugging params
-debug: 0
-debug_num_files: 1000000000
-seed: 24098
+debug: &debug 0
+debug_num_files: 10 # speeds up initialization
+seed: &seed 24098
 
 ### GQCNN CONFIG ###
 gqcnn:
@@ -66,8 +66,8 @@ gqcnn:
   im_height: 96
   im_width: 96
   im_channels: 1
-  debug: 0
-  seed: 24098
+  debug: *debug
+  seed: *seed
 
   # needs to match input data mode that was used for training, determines the pose dimensions for the network
   gripper_mode: suction

--- a/cfg/train.yaml
+++ b/cfg/train.yaml
@@ -55,9 +55,9 @@ gaussian_process_sigma: 0.005
 tensorboard_port: 6006
 
 # debugging params
-debug: 0
-debug_num_files: 1000000000
-seed: 24098
+debug: &debug 0
+debug_num_files: 10 # speeds up initialization
+seed: &seed 24098
 
 ### GQCNN CONFIG ###
 gqcnn:
@@ -65,8 +65,8 @@ gqcnn:
   im_height: 96
   im_width: 96
   im_channels: 1
-  debug: 0
-  seed: 24098
+  debug: *debug
+  seed: *seed
 
   # needs to match input data mode that was used for training, determines the pose dimensions for the network
   gripper_mode: parallel_jaw

--- a/cfg/train_dex-net_2.0.yaml
+++ b/cfg/train_dex-net_2.0.yaml
@@ -55,9 +55,9 @@ gaussian_process_sigma: 0.005
 tensorboard_port: 6006
 
 # debugging params
-debug: 0
-debug_num_files: 1000000000
-seed: 24098
+debug: &debug 0
+debug_num_files: 10 # speeds up initialization
+seed: &seed 24098
 
 ### GQCNN CONFIG ###
 gqcnn:
@@ -65,8 +65,8 @@ gqcnn:
   im_height: 32
   im_width: 32
   im_channels: 1
-  debug: 0
-  seed: 24098
+  debug: *debug
+  seed: *seed
 
   # needs to match input data mode that was used for training, determines the pose dimensions for the network
   gripper_mode: legacy_parallel_jaw

--- a/cfg/train_dex-net_3.0.yaml
+++ b/cfg/train_dex-net_3.0.yaml
@@ -55,9 +55,9 @@ gaussian_process_sigma: 0.005
 tensorboard_port: 6006
 
 # debugging params
-debug: 0
-debug_num_files: 1000000000
-seed: 24098
+debug: &debug 0
+debug_num_files: 10 # speeds up initialization
+seed: &seed 24098
 
 ### GQCNN CONFIG ###
 gqcnn:
@@ -65,8 +65,8 @@ gqcnn:
   im_height: 32
   im_width: 32
   im_channels: 1
-  debug: 0
-  seed: 24098
+  debug: *debug
+  seed: *seed
 
   # needs to match input data mode that was used for training, determines the pose dimensions for the network
   gripper_mode: legacy_suction

--- a/cfg/train_dex-net_4.0_fc_pj.yaml
+++ b/cfg/train_dex-net_4.0_fc_pj.yaml
@@ -55,9 +55,9 @@ gaussian_process_sigma: 0.005
 tensorboard_port: 6006
 
 # debugging params
-debug: 0
-debug_num_files: 1000000000
-seed: 24098
+debug: &debug 0
+debug_num_files: 10 # speeds up initialization
+seed: &seed 24098
 
 ### GQCNN CONFIG ###
 gqcnn:
@@ -65,8 +65,8 @@ gqcnn:
   im_height: 96
   im_width: 96
   im_channels: 1
-  debug: 0
-  seed: 24098
+  debug: *debug
+  seed: *seed
 
   # needs to match input data mode that was used for training, determines the pose dimensions for the network
   gripper_mode: parallel_jaw

--- a/cfg/train_dex-net_4.0_fc_suction.yaml
+++ b/cfg/train_dex-net_4.0_fc_suction.yaml
@@ -55,9 +55,9 @@ gaussian_process_sigma: 0.005
 tensorboard_port: 6006
 
 # debugging params
-debug: 0
-debug_num_files: 1000000000
-seed: 24098
+debug: &debug 0
+debug_num_files: 10 # speeds up initialization
+seed: &seed 24098
 
 ### GQCNN CONFIG ###
 gqcnn:
@@ -65,8 +65,8 @@ gqcnn:
   im_height: 96
   im_width: 96
   im_channels: 1
-  debug: 0
-  seed: 24098
+  debug: *debug
+  seed: *seed
 
   # needs to match input data mode that was used for training, determines the pose dimensions for the network
   gripper_mode: suction

--- a/cfg/train_dex-net_4.0_pj.yaml
+++ b/cfg/train_dex-net_4.0_pj.yaml
@@ -55,9 +55,9 @@ gaussian_process_sigma: 0.005
 tensorboard_port: 6006
 
 # debugging params
-debug: 0
-debug_num_files: 1000000000
-seed: 24098
+debug: &debug 0
+debug_num_files: 10 # speeds up initialization
+seed: &seed 24098
 
 ### GQCNN CONFIG ###
 gqcnn:
@@ -65,8 +65,8 @@ gqcnn:
   im_height: 96
   im_width: 96
   im_channels: 1
-  debug: 0
-  seed: 24098
+  debug: *debug
+  seed: *seed
 
   # needs to match input data mode that was used for training, determines the pose dimensions for the network
   gripper_mode: parallel_jaw

--- a/cfg/train_dex-net_4.0_suction.yaml
+++ b/cfg/train_dex-net_4.0_suction.yaml
@@ -55,9 +55,9 @@ gaussian_process_sigma: 0.005
 tensorboard_port: 6006
 
 # debugging params
-debug: 0
-debug_num_files: 1000000000
-seed: 24098
+debug: &debug 0
+debug_num_files: 10 # speeds up initialization
+seed: &seed 24098
 
 ### GQCNN CONFIG ###
 gqcnn:
@@ -65,8 +65,8 @@ gqcnn:
   im_height: 96
   im_width: 96
   im_channels: 1
-  debug: 0
-  seed: 24098
+  debug: *debug
+  seed: *seed
 
   # needs to match input data mode that was used for training, determines the pose dimensions for the network
   gripper_mode: suction

--- a/cfg/train_example_pj.yaml
+++ b/cfg/train_example_pj.yaml
@@ -55,9 +55,9 @@ gaussian_process_sigma: 0.005
 tensorboard_port: 6006
 
 # debugging params
-debug: 0
-debug_num_files: 1000000000
-seed: 24098
+debug: &debug 0
+debug_num_files: 10 # speeds up initialization
+seed: &seed 24098
 
 ### GQCNN CONFIG ###
 gqcnn:
@@ -65,8 +65,8 @@ gqcnn:
   im_height: 96
   im_width: 96
   im_channels: 1
-  debug: 0
-  seed: 24098
+  debug: *debug
+  seed: *seed
 
   # needs to match input data mode that was used for training, determines the pose dimensions for the network
   gripper_mode: parallel_jaw

--- a/cfg/train_example_suction.yaml
+++ b/cfg/train_example_suction.yaml
@@ -55,9 +55,9 @@ gaussian_process_sigma: 0.005
 tensorboard_port: 6006
 
 # debugging params
-debug: 0
-debug_num_files: 1000000000
-seed: 24098
+debug: &debug 0
+debug_num_files: 10 # speeds up initialization
+seed: &seed 24098
 
 ### GQCNN CONFIG ###
 gqcnn:
@@ -65,8 +65,8 @@ gqcnn:
   im_height: 96
   im_width: 96
   im_channels: 1
-  debug: 0
-  seed: 24098
+  debug: *debug
+  seed: *seed
 
   # needs to match input data mode that was used for training, determines the pose dimensions for the network
   gripper_mode: suction

--- a/cfg/train_fc.yaml
+++ b/cfg/train_fc.yaml
@@ -55,9 +55,9 @@ gaussian_process_sigma: 0.005
 tensorboard_port: 6006
 
 # debugging params
-debug: 0
-debug_num_files: 1000000000
-seed: 24098
+debug: &debug 0
+debug_num_files: 10 # speeds up initialization
+seed: &seed 24098
 
 ### GQCNN CONFIG ###
 gqcnn:
@@ -65,8 +65,8 @@ gqcnn:
   im_height: 96
   im_width: 96
   im_channels: 1
-  debug: 0
-  seed: 24098
+  debug: *debug
+  seed: *seed
 
   # needs to match input data mode that was used for training, determines the pose dimensions for the network
   gripper_mode: parallel_jaw

--- a/gqcnn/utils/enums.py
+++ b/gqcnn/utils/enums.py
@@ -29,6 +29,7 @@ import math
 # other constants
 class GeneralConstants:
     SEED = 3472134
+    SEED_SAMPLE_MAX = 2**32 - 1 # max range for seed (at least for np.random.seed)
     timeout_option = tf.RunOptions(timeout_in_ms=1000000)
     JSON_INDENT = 2
     MAX_PREFETCH_Q_SIZE = 250

--- a/tools/finetune.py
+++ b/tools/finetune.py
@@ -51,7 +51,7 @@ if __name__ == '__main__':
                         help='name of the split to train on')
     parser.add_argument('--output_dir', type=str, default=None,
                         help='path to store the model')
-    parser.add_argument('--tensorboard_port', type=int, default=6006,
+    parser.add_argument('--tensorboard_port', type=int, default=None,
                         help='port to launch tensorboard on')
     parser.add_argument('--seed', type=int, default=None,
                         help='random seed for training')
@@ -112,8 +112,11 @@ if __name__ == '__main__':
         
     # open train config
     train_config = YamlConfig(config_filename)
-    train_config['seed'] = seed
-    train_config['tensorboard_port'] = tensorboard_port
+    if seed is not None:
+        train_config['seed'] = seed
+        train_config['gqcnn']['seed'] = seed
+    if tensorboard_port is not None:
+        train_config['tensorboard_port'] = tensorboard_port
     gqcnn_params = train_config['gqcnn']
 
     # create a unique output folder based on the date and time

--- a/tools/finetune.py
+++ b/tools/finetune.py
@@ -137,4 +137,4 @@ if __name__ == '__main__':
                                          train_config,
                                          name=name)
     trainer.finetune(model_dir)
-    logger.info('Total Fine-tuning Time:' + str(utils.get_elapsed_time(time.time() - start_time))) 
+    logger.info('Total Fine-tuning Time: ' + str(utils.get_elapsed_time(time.time() - start_time))) 

--- a/tools/train.py
+++ b/tools/train.py
@@ -118,4 +118,4 @@ if __name__ == '__main__':
                                            train_config,
                                            name=name)
     trainer.train()
-    logger.info('Total Training Time:' + str(utils.get_elapsed_time(time.time() - start_time))) 
+    logger.info('Total Training Time: ' + str(utils.get_elapsed_time(time.time() - start_time))) 

--- a/tools/train.py
+++ b/tools/train.py
@@ -46,7 +46,7 @@ if __name__ == '__main__':
                         help='name of the split to train on')
     parser.add_argument('--output_dir', type=str, default=None,
                         help='path to store the model')
-    parser.add_argument('--tensorboard_port', type=int, default=6006,
+    parser.add_argument('--tensorboard_port', type=int, default=None,
                         help='port to launch tensorboard on')
     parser.add_argument('--seed', type=int, default=None,
                         help='random seed for training')
@@ -93,8 +93,11 @@ if __name__ == '__main__':
         
     # open train config
     train_config = YamlConfig(config_filename)
-    train_config['seed'] = seed
-    train_config['tensorboard_port'] = tensorboard_port
+    if seed is not None:
+        train_config['seed'] = seed
+        train_config['gqcnn']['seed'] = seed
+    if tensorboard_port is not None:
+        train_config['tensorboard_port'] = tensorboard_port
     gqcnn_params = train_config['gqcnn']
 
     # create a unique output folder based on the date and time


### PR DESCRIPTION
- Worker processes are now explicitly passed a unique random seed to prevent them from using the same one.
- A single worker still uses the random seed specified in the training config for reproducibility.
- Also fixed misc. issue of attempting to close Tensorboard process when it hadn't actually started (can happen when an exception is raised earlier on in the training pipeline).