### PR TITLE
Switched to generic IOError with check for ENOENT instead of FileNotFoundError for Python2.6,7/3+ compatibility.

### DIFF
--- a/gqcnn/model/tf/network_tf.py
+++ b/gqcnn/model/tf/network_tf.py
@@ -33,6 +33,7 @@ from __future__ import division
 from __future__ import print_function
 
 from collections import OrderedDict
+import errno
 from functools import reduce
 import json
 import math
@@ -242,12 +243,16 @@ class GQCNNTF(object):
                     os.path.join(model_dir, GQCNNFilenames.IM_MEAN))
                 self._im_std = np.load(
                     os.path.join(model_dir, GQCNNFilenames.IM_STD))
-            except FileNotFoundError:
-                # Support for legacy file naming convention.
-                self._im_mean = np.load(
-                    os.path.join(model_dir, GQCNNFilenames.LEG_MEAN))
-                self._im_std = np.load(
-                    os.path.join(model_dir, GQCNNFilenames.LEG_STD))
+            except IOError as e:  # Python 2.6,7/3+ compatibility.
+                if e.errno == errno.ENOENT:  # File not found.
+                    # Support for legacy file naming convention.
+                    self._im_mean = np.load(
+                        os.path.join(model_dir, GQCNNFilenames.LEG_MEAN))
+                    self._im_std = np.load(
+                        os.path.join(model_dir, GQCNNFilenames.LEG_STD))
+                else:
+                    # Some other IOError.
+                    raise e
             self._pose_mean = np.load(
                 os.path.join(model_dir, GQCNNFilenames.POSE_MEAN))
             self._pose_std = np.load(


### PR DESCRIPTION
As per https://stackoverflow.com/questions/26745283/how-do-i-import-filenotfounderror-from-python-3.