### PR TITLE
Fixed version of rtree to 0.8.3.

### DIFF
--- a/requirements/p2/cpu_requirements.txt
+++ b/requirements/p2/cpu_requirements.txt
@@ -11,3 +11,4 @@ scikit-learn
 scikit-image<=0.14.2
 gputil
 psutil
+rtree==0.8.3

--- a/requirements/p2/gpu_requirements.txt
+++ b/requirements/p2/gpu_requirements.txt
@@ -11,3 +11,4 @@ scikit-learn
 scikit-image<=0.14.2
 gputil
 psutil
+rtree==0.8.3

--- a/requirements/p3/cpu_requirements.txt
+++ b/requirements/p3/cpu_requirements.txt
@@ -10,3 +10,4 @@ scikit-learn
 scikit-image<=0.14.2
 gputil
 psutil
+rtree==0.8.3

--- a/requirements/p3/gpu_requirements.txt
+++ b/requirements/p3/gpu_requirements.txt
@@ -10,3 +10,4 @@ scikit-learn
 scikit-image<=0.14.2
 gputil
 psutil
+rtree==0.8.3

--- a/setup.py
+++ b/setup.py
@@ -141,9 +141,9 @@ class InstallCmd(install, object):
 
 
 requirements = [
-    "autolab-core", "autolab-perception", "visualization", "numpy", "scipy",
-    "matplotlib<=2.2.0", "opencv-python", "scikit-image<=0.14.2",
-    "scikit-learn", "psutil", "gputil", "rtree==0.8.3"
+    "rtree==0.8.3", "autolab-core", "autolab-perception", "visualization",
+    "numpy", "scipy", "matplotlib<=2.2.0", "opencv-python",
+    "scikit-image<=0.14.2", "scikit-learn", "psutil", "gputil"
 ]
 
 if sys.version[0] == "2":

--- a/setup.py
+++ b/setup.py
@@ -143,7 +143,7 @@ class InstallCmd(install, object):
 requirements = [
     "autolab-core", "autolab-perception", "visualization", "numpy", "scipy",
     "matplotlib<=2.2.0", "opencv-python", "scikit-image<=0.14.2",
-    "scikit-learn", "psutil", "gputil"
+    "scikit-learn", "psutil", "gputil", "rtree==0.8.3"
 ]
 
 if sys.version[0] == "2":


### PR DESCRIPTION
Pip installation of rtree > 0.8.3 fails with `OSError: libspatialindex_c.so: cannot open shared object file: No such file or directory`.