### PR TITLE
Dropping pyglet dep

### DIFF
--- a/requirements/p2/cpu_requirements.txt
+++ b/requirements/p2/cpu_requirements.txt
@@ -1,4 +1,3 @@
-pyglet==1.4.0b1
 autolab-core
 autolab-perception
 meshrender==0.0.9

--- a/requirements/p2/gpu_requirements.txt
+++ b/requirements/p2/gpu_requirements.txt
@@ -1,4 +1,3 @@
-pyglet==1.4.0b1
 autolab-core
 autolab-perception
 meshrender==0.0.9

--- a/requirements/p3/cpu_requirements.txt
+++ b/requirements/p3/cpu_requirements.txt
@@ -1,4 +1,3 @@
-pyglet==1.4.0b1
 autolab-core
 autolab-perception
 visualization

--- a/requirements/p3/gpu_requirements.txt
+++ b/requirements/p3/gpu_requirements.txt
@@ -1,4 +1,3 @@
-pyglet==1.4.0b1
 autolab-core
 autolab-perception
 visualization

--- a/setup.py
+++ b/setup.py
@@ -141,9 +141,8 @@ class InstallCmd(install, object):
 
 
 requirements = [
-    "autolab-core", "autolab-perception", "visualization",
-    "numpy", "scipy", "matplotlib<=2.2.0", "opencv-python", "scikit-learn",
-    "psutil", "gputil"
+    "autolab-core", "autolab-perception", "visualization", "numpy", "scipy",
+    "matplotlib<=2.2.0", "opencv-python", "scikit-learn", "psutil", "gputil"
 ]
 
 if sys.version[0] == "2":

--- a/setup.py
+++ b/setup.py
@@ -141,7 +141,7 @@ class InstallCmd(install, object):
 
 
 requirements = [
-    "pyglet==1.4.0b1", "autolab-core", "autolab-perception", "visualization",
+    "autolab-core", "autolab-perception", "visualization",
     "numpy", "scipy", "matplotlib<=2.2.0", "opencv-python", "scikit-learn",
     "psutil", "gputil"
 ]


### PR DESCRIPTION
Explicit dep is no longer needed and conflicts with pyrender.