### PR TITLE
Removing scipy.misc.imresize

### DIFF
--- a/gqcnn/training/tf/trainer_tf.py
+++ b/gqcnn/training/tf/trainer_tf.py
@@ -56,9 +56,8 @@ import autolab_core.utils as utils
 
 from ...utils import (TrainingMode, GripperMode, InputDepthMode,
                       GeneralConstants, TrainStatsLogger, GQCNNTrainingStatus,
-                      GQCNNFilenames,
-                      pose_dim, read_pose_data, weight_name_to_layer_name,
-                      is_py2, imresize)
+                      GQCNNFilenames, pose_dim, read_pose_data,
+                      weight_name_to_layer_name, is_py2, imresize)
 
 if is_py2():
     import Queue
@@ -1483,8 +1482,7 @@ class GQCNNTrainerTF(object):
                             resized_train_images_arr[i, :, :, c] = imresize(
                                 train_images_arr[i, :, :, c],
                                 rescale_factor,
-                                interp="bicubic"
-                            )
+                                interp="bicubic")
                     train_images_arr = resized_train_images_arr
 
                 # Add noises to images.

--- a/gqcnn/training/tf/trainer_tf.py
+++ b/gqcnn/training/tf/trainer_tf.py
@@ -46,7 +46,6 @@ import time
 from past.builtins import xrange
 import cv2
 import numpy as np
-import scipy.misc as sm
 import scipy.stats as ss
 import tensorflow as tf
 
@@ -56,9 +55,10 @@ from autolab_core.constants import JSON_INDENT
 import autolab_core.utils as utils
 
 from ...utils import (TrainingMode, GripperMode, InputDepthMode,
-                      GeneralConstants, TrainStatsLogger, pose_dim,
-                      read_pose_data, weight_name_to_layer_name, is_py2,
-                      GQCNNTrainingStatus, GQCNNFilenames)
+                      GeneralConstants, TrainStatsLogger, GQCNNTrainingStatus,
+                      GQCNNFilenames,
+                      pose_dim, read_pose_data, weight_name_to_layer_name,
+                      is_py2, imresize)
 
 if is_py2():
     import Queue
@@ -1480,11 +1480,11 @@ class GQCNNTrainerTF(object):
                     ]).astype(np.float32)
                     for i in range(num_images):
                         for c in range(train_images_arr.shape[3]):
-                            resized_train_images_arr[i, :, :, c] = sm.imresize(
+                            resized_train_images_arr[i, :, :, c] = imresize(
                                 train_images_arr[i, :, :, c],
                                 rescale_factor,
-                                interp="bicubic",
-                                mode="F")
+                                interp="bicubic"
+                            )
                     train_images_arr = resized_train_images_arr
 
                 # Add noises to images.
@@ -1583,10 +1583,9 @@ class GQCNNTrainerTF(object):
                                            size=self.gp_num_pix).reshape(
                                                self.gp_sample_height,
                                                self.gp_sample_width)
-                    gp_noise = sm.imresize(gp_noise,
-                                           self.gp_rescale_factor,
-                                           interp="bicubic",
-                                           mode="F")
+                    gp_noise = imresize(gp_noise,
+                                        self.gp_rescale_factor,
+                                        interp="bicubic")
                     train_image[train_image > 0] += gp_noise[train_image > 0]
                     image_arr[i, :, :, 0] = train_image
 

--- a/gqcnn/utils/__init__.py
+++ b/gqcnn/utils/__init__.py
@@ -36,8 +36,8 @@ from .utils import (is_py2, set_cuda_visible_devices, pose_dim, read_pose_data,
 
 __all__ = [
     "is_py2", "set_cuda_visible_devices", "pose_dim", "read_pose_data",
-    "reduce_shape", "weight_name_to_layer_name", "imresize",
-    "ImageMode", "TrainingMode", "GripperMode", "InputDepthMode",
-    "GeneralConstants", "GQCNNTrainingStatus", "NoValidGraspsException",
+    "reduce_shape", "weight_name_to_layer_name", "imresize", "ImageMode",
+    "TrainingMode", "GripperMode", "InputDepthMode", "GeneralConstants",
+    "GQCNNTrainingStatus", "NoValidGraspsException",
     "NoAntipodalPairsFoundException", "TrainStatsLogger", "GQCNNFilenames"
 ]

--- a/gqcnn/utils/__init__.py
+++ b/gqcnn/utils/__init__.py
@@ -32,12 +32,12 @@ from .policy_exceptions import (NoValidGraspsException,
                                 NoAntipodalPairsFoundException)
 from .train_stats_logger import TrainStatsLogger
 from .utils import (is_py2, set_cuda_visible_devices, pose_dim, read_pose_data,
-                    reduce_shape, weight_name_to_layer_name)
+                    reduce_shape, weight_name_to_layer_name, imresize)
 
 __all__ = [
     "is_py2", "set_cuda_visible_devices", "pose_dim", "read_pose_data",
-    "reduce_shape", "weight_name_to_layer_name", "ImageMode", "TrainingMode",
-    "GripperMode", "InputDepthMode", "GeneralConstants", "GQCNNTrainingStatus",
-    "NoValidGraspsException", "NoAntipodalPairsFoundException",
-    "TrainStatsLogger", "GQCNNFilenames"
+    "reduce_shape", "weight_name_to_layer_name", "imresize",
+    "ImageMode", "TrainingMode", "GripperMode", "InputDepthMode",
+    "GeneralConstants", "GQCNNTrainingStatus", "NoValidGraspsException",
+    "NoAntipodalPairsFoundException", "TrainStatsLogger", "GQCNNFilenames"
 ]

--- a/gqcnn/utils/utils.py
+++ b/gqcnn/utils/utils.py
@@ -178,7 +178,7 @@ def weight_name_to_layer_name(weight_name):
 
 def imresize(image, size, interp="nearest"):
     """Wrapper over `skimage.transform.resize` to mimic `scipy.misc.imresize`.
-    Copied from https://github.com/BerkeleyAutomation/perception/blob/master/perception/image.py#L38.
+    Copied from https://github.com/BerkeleyAutomation/perception/blob/master/perception/image.py#L38.  # noqa: E501
 
     Since `scipy.misc.imresize` has been removed in version 1.3.*, instead use
     `skimage.transform.resize`. The "lanczos" and "cubic" interpolation methods
@@ -205,12 +205,18 @@ def imresize(image, size, interp="nearest"):
     :obj:`np.ndarray`
         The resized image.
     """
-    skt_interp_map = {"nearest": 0, "bilinear": 1, "biquadratic": 2,
-                      "bicubic": 3, "biquartic": 4, "biquintic": 5}
+    skt_interp_map = {
+        "nearest": 0,
+        "bilinear": 1,
+        "biquadratic": 2,
+        "bicubic": 3,
+        "biquartic": 4,
+        "biquintic": 5
+    }
     if interp in ("lanczos", "cubic"):
-        raise ValueError("\"lanczos\" and \"cubic\""
+        raise ValueError("'lanczos' and 'cubic'"
                          " interpolation are no longer supported.")
-    assert interp in skt_interp_map, ("Interpolation \"{}\" not"
+    assert interp in skt_interp_map, ("Interpolation '{}' not"
                                       " supported.".format(interp))
 
     if isinstance(size, (tuple, list)):
@@ -224,7 +230,7 @@ def imresize(image, size, interp="nearest"):
         np_shape[0:2] *= size / 100.0
         output_shape = tuple(np_shape.astype(int))
     else:
-        raise ValueError("Invalid type for size \"{}\".".format(type(size)))
+        raise ValueError("Invalid type for size '{}'.".format(type(size)))
 
     return skt.resize(image,
                       output_shape,


### PR DESCRIPTION
Removing `scipy.misc.imresize`, which has been removed in 1.3.0, and switching to `skimage.transform.resize`.