### PR TITLE
Cleaning configs

### DIFF
--- a/cfg/examples/antipodal_grasp_sampling.yaml
+++ b/cfg/examples/antipodal_grasp_sampling.yaml
@@ -1,25 +1,3 @@
-# Copyright ©2017. The Regents of the University of California (Regents).
-# All Rights Reserved. Permission to use, copy, modify, and distribute this
-# software and its documentation for educational, research, and not-for-profit
-# purposes, without fee and without a signed licensing agreement, is hereby
-# granted, provided that the above copyright notice, this paragraph and the
-# following two paragraphs appear in all copies, modifications, and
-# distributions. Contact The Office of Technology Licensing, UC Berkeley, 2150
-# Shattuck Avenue, Suite 510, Berkeley, CA 94720-1620, (510) 643-7201,
-# otl@berkeley.edu,
-# http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
-
-# IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
-# INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
-# THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN
-# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-# REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
-# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-# PURPOSE. THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED
-# HEREUNDER IS PROVIDED "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE
-# MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
-
 # policy params
 policy:
   # general params

--- a/cfg/examples/fc_gqcnn_pj.yaml
+++ b/cfg/examples/fc_gqcnn_pj.yaml
@@ -1,25 +1,3 @@
-# Copyright ©2017. The Regents of the University of California (Regents).
-# All Rights Reserved. Permission to use, copy, modify, and distribute this
-# software and its documentation for educational, research, and not-for-profit
-# purposes, without fee and without a signed licensing agreement, is hereby
-# granted, provided that the above copyright notice, this paragraph and the
-# following two paragraphs appear in all copies, modifications, and
-# distributions. Contact The Office of Technology Licensing, UC Berkeley, 2150
-# Shattuck Avenue, Suite 510, Berkeley, CA 94720-1620, (510) 643-7201,
-# otl@berkeley.edu,
-# http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
-
-# IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
-# INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
-# THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN
-# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-# REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
-# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-# PURPOSE. THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED
-# HEREUNDER IS PROVIDED "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE
-# MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
-
 policy:
   type: fully_conv_pj
 

--- a/cfg/examples/fc_gqcnn_suction.yaml
+++ b/cfg/examples/fc_gqcnn_suction.yaml
@@ -1,25 +1,3 @@
-# Copyright ©2017. The Regents of the University of California (Regents).
-# All Rights Reserved. Permission to use, copy, modify, and distribute this
-# software and its documentation for educational, research, and not-for-profit
-# purposes, without fee and without a signed licensing agreement, is hereby
-# granted, provided that the above copyright notice, this paragraph and the
-# following two paragraphs appear in all copies, modifications, and
-# distributions. Contact The Office of Technology Licensing, UC Berkeley, 2150
-# Shattuck Avenue, Suite 510, Berkeley, CA 94720-1620, (510) 643-7201,
-# otl@berkeley.edu,
-# http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
-
-# IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
-# INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
-# THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN
-# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-# REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
-# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-# PURPOSE. THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED
-# HEREUNDER IS PROVIDED "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE
-# MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
-
 policy:
   type: fully_conv_suction
 

--- a/cfg/examples/gqcnn_pj.yaml
+++ b/cfg/examples/gqcnn_pj.yaml
@@ -1,25 +1,3 @@
-# Copyright ©2017. The Regents of the University of California (Regents).
-# All Rights Reserved. Permission to use, copy, modify, and distribute this
-# software and its documentation for educational, research, and not-for-profit
-# purposes, without fee and without a signed licensing agreement, is hereby
-# granted, provided that the above copyright notice, this paragraph and the
-# following two paragraphs appear in all copies, modifications, and
-# distributions. Contact The Office of Technology Licensing, UC Berkeley, 2150
-# Shattuck Avenue, Suite 510, Berkeley, CA 94720-1620, (510) 643-7201,
-# otl@berkeley.edu,
-# http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
-
-# IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
-# INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
-# THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN
-# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-# REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
-# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-# PURPOSE. THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED
-# HEREUNDER IS PROVIDED "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE
-# MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
-
 policy:
   # optimization params
   num_seed_samples: 128
@@ -63,7 +41,7 @@ policy:
   metric:
     type: gqcnn
     gqcnn_model: models/GQCNN-4.0-PJ
-    
+
     crop_height: 96
     crop_width: 96
 

--- a/cfg/examples/gqcnn_suction.yaml
+++ b/cfg/examples/gqcnn_suction.yaml
@@ -1,25 +1,3 @@
-# Copyright ©2017. The Regents of the University of California (Regents).
-# All Rights Reserved. Permission to use, copy, modify, and distribute this
-# software and its documentation for educational, research, and not-for-profit
-# purposes, without fee and without a signed licensing agreement, is hereby
-# granted, provided that the above copyright notice, this paragraph and the
-# following two paragraphs appear in all copies, modifications, and
-# distributions. Contact The Office of Technology Licensing, UC Berkeley, 2150
-# Shattuck Avenue, Suite 510, Berkeley, CA 94720-1620, (510) 643-7201,
-# otl@berkeley.edu,
-# http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
-
-# IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
-# INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
-# THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN
-# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-# REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
-# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-# PURPOSE. THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED
-# HEREUNDER IS PROVIDED "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE
-# MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
-
 policy:
   # optimization params
   num_seed_samples: 200

--- a/cfg/examples/replication/dex-net_2.0.yaml
+++ b/cfg/examples/replication/dex-net_2.0.yaml
@@ -1,25 +1,3 @@
-# Copyright ©2017. The Regents of the University of California (Regents).
-# All Rights Reserved. Permission to use, copy, modify, and distribute this
-# software and its documentation for educational, research, and not-for-profit
-# purposes, without fee and without a signed licensing agreement, is hereby
-# granted, provided that the above copyright notice, this paragraph and the
-# following two paragraphs appear in all copies, modifications, and
-# distributions. Contact The Office of Technology Licensing, UC Berkeley, 2150
-# Shattuck Avenue, Suite 510, Berkeley, CA 94720-1620, (510) 643-7201,
-# otl@berkeley.edu,
-# http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
-
-# IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
-# INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
-# THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN
-# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-# REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
-# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-# PURPOSE. THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED
-# HEREUNDER IS PROVIDED "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE
-# MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
-
 # policy params
 policy:
   # optimization params
@@ -64,7 +42,7 @@ policy:
   metric:
     type: gqcnn
     gqcnn_model: models/GQCNN-2.0
-    
+
     crop_height: 96
     crop_width: 96
 

--- a/cfg/examples/replication/dex-net_2.1.yaml
+++ b/cfg/examples/replication/dex-net_2.1.yaml
@@ -1,25 +1,3 @@
-# Copyright ©2017. The Regents of the University of California (Regents).
-# All Rights Reserved. Permission to use, copy, modify, and distribute this
-# software and its documentation for educational, research, and not-for-profit
-# purposes, without fee and without a signed licensing agreement, is hereby
-# granted, provided that the above copyright notice, this paragraph and the
-# following two paragraphs appear in all copies, modifications, and
-# distributions. Contact The Office of Technology Licensing, UC Berkeley, 2150
-# Shattuck Avenue, Suite 510, Berkeley, CA 94720-1620, (510) 643-7201,
-# otl@berkeley.edu,
-# http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
-
-# IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
-# INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
-# THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN
-# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-# REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
-# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-# PURPOSE. THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED
-# HEREUNDER IS PROVIDED "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE
-# MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
-
 # policy params
 policy:
   # optimization params
@@ -64,7 +42,7 @@ policy:
   metric:
     type: gqcnn
     gqcnn_model: models/GQCNN-2.1
-    
+
     crop_height: 96
     crop_width: 96
 

--- a/cfg/examples/replication/dex-net_3.0.yaml
+++ b/cfg/examples/replication/dex-net_3.0.yaml
@@ -1,25 +1,3 @@
-# Copyright ©2017. The Regents of the University of California (Regents).
-# All Rights Reserved. Permission to use, copy, modify, and distribute this
-# software and its documentation for educational, research, and not-for-profit
-# purposes, without fee and without a signed licensing agreement, is hereby
-# granted, provided that the above copyright notice, this paragraph and the
-# following two paragraphs appear in all copies, modifications, and
-# distributions. Contact The Office of Technology Licensing, UC Berkeley, 2150
-# Shattuck Avenue, Suite 510, Berkeley, CA 94720-1620, (510) 643-7201,
-# otl@berkeley.edu,
-# http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
-
-# IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
-# INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
-# THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN
-# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-# REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
-# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-# PURPOSE. THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED
-# HEREUNDER IS PROVIDED "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE
-# MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
-
 # policy params
 policy:
   # optimization params

--- a/cfg/examples/replication/dex-net_4.0_fc_pj.yaml
+++ b/cfg/examples/replication/dex-net_4.0_fc_pj.yaml
@@ -1,25 +1,3 @@
-# Copyright ©2017. The Regents of the University of California (Regents).
-# All Rights Reserved. Permission to use, copy, modify, and distribute this
-# software and its documentation for educational, research, and not-for-profit
-# purposes, without fee and without a signed licensing agreement, is hereby
-# granted, provided that the above copyright notice, this paragraph and the
-# following two paragraphs appear in all copies, modifications, and
-# distributions. Contact The Office of Technology Licensing, UC Berkeley, 2150
-# Shattuck Avenue, Suite 510, Berkeley, CA 94720-1620, (510) 643-7201,
-# otl@berkeley.edu,
-# http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
-
-# IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
-# INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
-# THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN
-# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-# REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
-# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-# PURPOSE. THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED
-# HEREUNDER IS PROVIDED "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE
-# MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
-
 policy:
   type: fully_conv_pj
 

--- a/cfg/examples/replication/dex-net_4.0_fc_suction.yaml
+++ b/cfg/examples/replication/dex-net_4.0_fc_suction.yaml
@@ -1,25 +1,3 @@
-# Copyright ©2017. The Regents of the University of California (Regents).
-# All Rights Reserved. Permission to use, copy, modify, and distribute this
-# software and its documentation for educational, research, and not-for-profit
-# purposes, without fee and without a signed licensing agreement, is hereby
-# granted, provided that the above copyright notice, this paragraph and the
-# following two paragraphs appear in all copies, modifications, and
-# distributions. Contact The Office of Technology Licensing, UC Berkeley, 2150
-# Shattuck Avenue, Suite 510, Berkeley, CA 94720-1620, (510) 643-7201,
-# otl@berkeley.edu,
-# http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
-
-# IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
-# INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
-# THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN
-# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-# REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
-# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-# PURPOSE. THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED
-# HEREUNDER IS PROVIDED "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE
-# MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
-
 policy:
   type: fully_conv_suction
 

--- a/cfg/examples/replication/dex-net_4.0_pj.yaml
+++ b/cfg/examples/replication/dex-net_4.0_pj.yaml
@@ -1,25 +1,3 @@
-# Copyright ©2017. The Regents of the University of California (Regents).
-# All Rights Reserved. Permission to use, copy, modify, and distribute this
-# software and its documentation for educational, research, and not-for-profit
-# purposes, without fee and without a signed licensing agreement, is hereby
-# granted, provided that the above copyright notice, this paragraph and the
-# following two paragraphs appear in all copies, modifications, and
-# distributions. Contact The Office of Technology Licensing, UC Berkeley, 2150
-# Shattuck Avenue, Suite 510, Berkeley, CA 94720-1620, (510) 643-7201,
-# otl@berkeley.edu,
-# http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
-
-# IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
-# INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
-# THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN
-# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-# REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
-# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-# PURPOSE. THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED
-# HEREUNDER IS PROVIDED "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE
-# MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
-
 policy:
   # optimization params
   num_seed_samples: 128
@@ -63,7 +41,7 @@ policy:
   metric:
     type: gqcnn
     gqcnn_model: models/GQCNN-4.0-PJ
-    
+
     crop_height: 96
     crop_width: 96
 

--- a/cfg/examples/replication/dex-net_4.0_suction.yaml
+++ b/cfg/examples/replication/dex-net_4.0_suction.yaml
@@ -1,25 +1,3 @@
-# Copyright ©2017. The Regents of the University of California (Regents).
-# All Rights Reserved. Permission to use, copy, modify, and distribute this
-# software and its documentation for educational, research, and not-for-profit
-# purposes, without fee and without a signed licensing agreement, is hereby
-# granted, provided that the above copyright notice, this paragraph and the
-# following two paragraphs appear in all copies, modifications, and
-# distributions. Contact The Office of Technology Licensing, UC Berkeley, 2150
-# Shattuck Avenue, Suite 510, Berkeley, CA 94720-1620, (510) 643-7201,
-# otl@berkeley.edu,
-# http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
-
-# IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
-# INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
-# THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN
-# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-# REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
-# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-# PURPOSE. THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED
-# HEREUNDER IS PROVIDED "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE
-# MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
-
 policy:
   # optimization params
   num_seed_samples: 200

--- a/cfg/examples/ros/fc_gqcnn_pj.yaml
+++ b/cfg/examples/ros/fc_gqcnn_pj.yaml
@@ -1,25 +1,3 @@
-# Copyright ©2017. The Regents of the University of California (Regents).
-# All Rights Reserved. Permission to use, copy, modify, and distribute this
-# software and its documentation for educational, research, and not-for-profit
-# purposes, without fee and without a signed licensing agreement, is hereby
-# granted, provided that the above copyright notice, this paragraph and the
-# following two paragraphs appear in all copies, modifications, and
-# distributions. Contact The Office of Technology Licensing, UC Berkeley, 2150
-# Shattuck Avenue, Suite 510, Berkeley, CA 94720-1620, (510) 643-7201,
-# otl@berkeley.edu,
-# http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
-
-# IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
-# INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
-# THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN
-# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-# REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
-# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-# PURPOSE. THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED
-# HEREUNDER IS PROVIDED "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE
-# MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
-
 !include ../fc_gqcnn_pj.yaml
 
 # ROS-specific visualization

--- a/cfg/examples/ros/fc_gqcnn_suction.yaml
+++ b/cfg/examples/ros/fc_gqcnn_suction.yaml
@@ -1,25 +1,3 @@
-# Copyright ©2017. The Regents of the University of California (Regents).
-# All Rights Reserved. Permission to use, copy, modify, and distribute this
-# software and its documentation for educational, research, and not-for-profit
-# purposes, without fee and without a signed licensing agreement, is hereby
-# granted, provided that the above copyright notice, this paragraph and the
-# following two paragraphs appear in all copies, modifications, and
-# distributions. Contact The Office of Technology Licensing, UC Berkeley, 2150
-# Shattuck Avenue, Suite 510, Berkeley, CA 94720-1620, (510) 643-7201,
-# otl@berkeley.edu,
-# http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
-
-# IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
-# INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
-# THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN
-# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-# REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
-# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-# PURPOSE. THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED
-# HEREUNDER IS PROVIDED "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE
-# MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
-
 !include ../fc_gqcnn_suction.yaml
 
 # ROS-specific visualization

--- a/cfg/examples/ros/gqcnn_pj.yaml
+++ b/cfg/examples/ros/gqcnn_pj.yaml
@@ -1,25 +1,3 @@
-# Copyright ©2017. The Regents of the University of California (Regents).
-# All Rights Reserved. Permission to use, copy, modify, and distribute this
-# software and its documentation for educational, research, and not-for-profit
-# purposes, without fee and without a signed licensing agreement, is hereby
-# granted, provided that the above copyright notice, this paragraph and the
-# following two paragraphs appear in all copies, modifications, and
-# distributions. Contact The Office of Technology Licensing, UC Berkeley, 2150
-# Shattuck Avenue, Suite 510, Berkeley, CA 94720-1620, (510) 643-7201,
-# otl@berkeley.edu,
-# http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
-
-# IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
-# INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
-# THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN
-# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-# REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
-# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-# PURPOSE. THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED
-# HEREUNDER IS PROVIDED "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE
-# MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
-
 !include ../gqcnn_pj.yaml
 
 # ROS-specific visualization

--- a/cfg/examples/ros/gqcnn_suction.yaml
+++ b/cfg/examples/ros/gqcnn_suction.yaml
@@ -1,25 +1,3 @@
-# Copyright ©2017. The Regents of the University of California (Regents).
-# All Rights Reserved. Permission to use, copy, modify, and distribute this
-# software and its documentation for educational, research, and not-for-profit
-# purposes, without fee and without a signed licensing agreement, is hereby
-# granted, provided that the above copyright notice, this paragraph and the
-# following two paragraphs appear in all copies, modifications, and
-# distributions. Contact The Office of Technology Licensing, UC Berkeley, 2150
-# Shattuck Avenue, Suite 510, Berkeley, CA 94720-1620, (510) 643-7201,
-# otl@berkeley.edu,
-# http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
-
-# IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
-# INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
-# THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN
-# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-# REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
-# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-# PURPOSE. THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED
-# HEREUNDER IS PROVIDED "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE
-# MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
-
 !include ../gqcnn_suction.yaml
 
 # ROS-specific visualization

--- a/cfg/finetune.yaml
+++ b/cfg/finetune.yaml
@@ -1,25 +1,3 @@
-# Copyright ©2017. The Regents of the University of California (Regents).
-# All Rights Reserved. Permission to use, copy, modify, and distribute this
-# software and its documentation for educational, research, and not-for-profit
-# purposes, without fee and without a signed licensing agreement, is hereby
-# granted, provided that the above copyright notice, this paragraph and the
-# following two paragraphs appear in all copies, modifications, and
-# distributions. Contact The Office of Technology Licensing, UC Berkeley, 2150
-# Shattuck Avenue, Suite 510, Berkeley, CA 94720-1620, (510) 643-7201,
-# otl@berkeley.edu,
-# http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
-
-# IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
-# INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
-# THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN
-# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-# REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
-# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-# PURPOSE. THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED
-# HEREUNDER IS PROVIDED "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE
-# MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
-
 # general optimization params
 train_batch_size: 64
 val_batch_size: &val_batch_size 64

--- a/cfg/finetune_dex-net_4.0_pj.yaml
+++ b/cfg/finetune_dex-net_4.0_pj.yaml
@@ -1,25 +1,3 @@
-# Copyright ©2017. The Regents of the University of California (Regents).
-# All Rights Reserved. Permission to use, copy, modify, and distribute this
-# software and its documentation for educational, research, and not-for-profit
-# purposes, without fee and without a signed licensing agreement, is hereby
-# granted, provided that the above copyright notice, this paragraph and the
-# following two paragraphs appear in all copies, modifications, and
-# distributions. Contact The Office of Technology Licensing, UC Berkeley, 2150
-# Shattuck Avenue, Suite 510, Berkeley, CA 94720-1620, (510) 643-7201,
-# otl@berkeley.edu,
-# http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
-
-# IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
-# INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
-# THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN
-# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-# REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
-# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-# PURPOSE. THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED
-# HEREUNDER IS PROVIDED "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE
-# MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
-
 # general optimization params
 train_batch_size: 64
 val_batch_size: &val_batch_size 64

--- a/cfg/finetune_dex-net_4.0_suction.yaml
+++ b/cfg/finetune_dex-net_4.0_suction.yaml
@@ -1,25 +1,3 @@
-# Copyright ©2017. The Regents of the University of California (Regents).
-# All Rights Reserved. Permission to use, copy, modify, and distribute this
-# software and its documentation for educational, research, and not-for-profit
-# purposes, without fee and without a signed licensing agreement, is hereby
-# granted, provided that the above copyright notice, this paragraph and the
-# following two paragraphs appear in all copies, modifications, and
-# distributions. Contact The Office of Technology Licensing, UC Berkeley, 2150
-# Shattuck Avenue, Suite 510, Berkeley, CA 94720-1620, (510) 643-7201,
-# otl@berkeley.edu,
-# http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
-
-# IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
-# INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
-# THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN
-# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-# REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
-# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-# PURPOSE. THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED
-# HEREUNDER IS PROVIDED "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE
-# MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
-
 # general optimization params
 train_batch_size: 64
 val_batch_size: &val_batch_size 64

--- a/cfg/finetune_example_pj.yaml
+++ b/cfg/finetune_example_pj.yaml
@@ -1,25 +1,3 @@
-# Copyright ©2017. The Regents of the University of California (Regents).
-# All Rights Reserved. Permission to use, copy, modify, and distribute this
-# software and its documentation for educational, research, and not-for-profit
-# purposes, without fee and without a signed licensing agreement, is hereby
-# granted, provided that the above copyright notice, this paragraph and the
-# following two paragraphs appear in all copies, modifications, and
-# distributions. Contact The Office of Technology Licensing, UC Berkeley, 2150
-# Shattuck Avenue, Suite 510, Berkeley, CA 94720-1620, (510) 643-7201,
-# otl@berkeley.edu,
-# http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
-
-# IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
-# INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
-# THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN
-# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-# REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
-# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-# PURPOSE. THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED
-# HEREUNDER IS PROVIDED "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE
-# MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
-
 # general optimization params
 train_batch_size: 64
 val_batch_size: &val_batch_size 64

--- a/cfg/finetune_example_suction.yaml
+++ b/cfg/finetune_example_suction.yaml
@@ -1,25 +1,3 @@
-# Copyright ©2017. The Regents of the University of California (Regents).
-# All Rights Reserved. Permission to use, copy, modify, and distribute this
-# software and its documentation for educational, research, and not-for-profit
-# purposes, without fee and without a signed licensing agreement, is hereby
-# granted, provided that the above copyright notice, this paragraph and the
-# following two paragraphs appear in all copies, modifications, and
-# distributions. Contact The Office of Technology Licensing, UC Berkeley, 2150
-# Shattuck Avenue, Suite 510, Berkeley, CA 94720-1620, (510) 643-7201,
-# otl@berkeley.edu,
-# http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
-
-# IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
-# INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
-# THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN
-# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-# REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
-# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-# PURPOSE. THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED
-# HEREUNDER IS PROVIDED "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE
-# MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
-
 # general optimization params
 train_batch_size: 64
 val_batch_size: &val_batch_size 64

--- a/cfg/hyperparam_search/train_dex-net_4.0_fc_suction_hyperparam_search.yaml
+++ b/cfg/hyperparam_search/train_dex-net_4.0_fc_suction_hyperparam_search.yaml
@@ -1,25 +1,3 @@
-# Copyright ©2017. The Regents of the University of California (Regents).
-# All Rights Reserved. Permission to use, copy, modify, and distribute this
-# software and its documentation for educational, research, and not-for-profit
-# purposes, without fee and without a signed licensing agreement, is hereby
-# granted, provided that the above copyright notice, this paragraph and the
-# following two paragraphs appear in all copies, modifications, and
-# distributions. Contact The Office of Technology Licensing, UC Berkeley, 2150
-# Shattuck Avenue, Suite 510, Berkeley, CA 94720-1620, (510) 643-7201,
-# otl@berkeley.edu,
-# http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
-
-# IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
-# INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
-# THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN
-# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-# REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
-# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-# PURPOSE. THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED
-# HEREUNDER IS PROVIDED "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE
-# MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
-
 # general optimization params
 train_batch_size: 64
 val_batch_size: &val_batch_size 64

--- a/cfg/hyperparam_search/train_hyperparam_search.yaml
+++ b/cfg/hyperparam_search/train_hyperparam_search.yaml
@@ -1,26 +1,6 @@
-# Copyright ©2017. The Regents of the University of California (Regents).
-# All Rights Reserved. Permission to use, copy, modify, and distribute this
-# software and its documentation for educational, research, and not-for-profit
-# purposes, without fee and without a signed licensing agreement, is hereby
-# granted, provided that the above copyright notice, this paragraph and the
-# following two paragraphs appear in all copies, modifications, and
-# distributions. Contact The Office of Technology Licensing, UC Berkeley, 2150
-# Shattuck Avenue, Suite 510, Berkeley, CA 94720-1620, (510) 643-7201,
-# otl@berkeley.edu,
-# http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
-
-# IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
-# INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
-# THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN
-# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-# REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
-# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-# PURPOSE. THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED
-# HEREUNDER IS PROVIDED "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE
-# MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
-
-### Example hyper-parameter search config corresponding to cfg/train.yaml that grid-searches through number of training epochs, base learning rate, and conv1_1 filter sizes. ###
+# Example hyper-parameter search config corresponding to cfg/train.yaml that
+# grid-searches through number of training epochs, base learning rate, and
+# conv1_1 filter sizes.
 
 # general optimization params
 train_batch_size: 64
@@ -33,7 +13,7 @@ save_frequency: 10    # how often to save output (in epochs)
 vis_frequency: 10000  # how often to visualize filters (in epochs)
 log_frequency: 1      # how often to log output (in steps)
 
-# train / val split params 
+# train / val split params
 train_pct: 0.9              # percentage of the data to use for training vs validation
 total_pct: 1.0              # percentage of all the files to use
 eval_total_train_error: 0   # whether or not to evaluate the total training error on each validataion

--- a/cfg/tools/analyze_gqcnn_performance.yaml
+++ b/cfg/tools/analyze_gqcnn_performance.yaml
@@ -1,25 +1,3 @@
-# Copyright ©2017. The Regents of the University of California (Regents).
-# All Rights Reserved. Permission to use, copy, modify, and distribute this
-# software and its documentation for educational, research, and not-for-profit
-# purposes, without fee and without a signed licensing agreement, is hereby
-# granted, provided that the above copyright notice, this paragraph and the
-# following two paragraphs appear in all copies, modifications, and
-# distributions. Contact The Office of Technology Licensing, UC Berkeley, 2150
-# Shattuck Avenue, Suite 510, Berkeley, CA 94720-1620, (510) 643-7201,
-# otl@berkeley.edu,
-# http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
-
-# IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
-# INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
-# THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN
-# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-# REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
-# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-# PURPOSE. THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED
-# HEREUNDER IS PROVIDED "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE
-# MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
-
 log_rate: 10
 font_size: 15
 line_width: 4

--- a/cfg/tools/run_policy.yaml
+++ b/cfg/tools/run_policy.yaml
@@ -1,25 +1,3 @@
-# Copyright ©2017. The Regents of the University of California (Regents).
-# All Rights Reserved. Permission to use, copy, modify, and distribute this
-# software and its documentation for educational, research, and not-for-profit
-# purposes, without fee and without a signed licensing agreement, is hereby
-# granted, provided that the above copyright notice, this paragraph and the
-# following two paragraphs appear in all copies, modifications, and
-# distributions. Contact The Office of Technology Licensing, UC Berkeley, 2150
-# Shattuck Avenue, Suite 510, Berkeley, CA 94720-1620, (510) 643-7201,
-# otl@berkeley.edu,
-# http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
-
-# IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
-# INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
-# THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN
-# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-# REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
-# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-# PURPOSE. THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED
-# HEREUNDER IS PROVIDED "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE
-# MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
-
 # policy params
 policy:
     # optimization params
@@ -37,7 +15,7 @@ policy:
     gripper_width: 0.05
     max_approach_angle: 60
     logging_dir: logs/debug
-    
+
     # sampling params
     sampling:
       # type
@@ -108,7 +86,7 @@ policy:
       final_grasp: 1
 
       grasp_scale: 1
-      
+
       vmin: 0.6
       vmax: 0.9
 

--- a/cfg/train.yaml
+++ b/cfg/train.yaml
@@ -1,25 +1,3 @@
-# Copyright ©2017. The Regents of the University of California (Regents).
-# All Rights Reserved. Permission to use, copy, modify, and distribute this
-# software and its documentation for educational, research, and not-for-profit
-# purposes, without fee and without a signed licensing agreement, is hereby
-# granted, provided that the above copyright notice, this paragraph and the
-# following two paragraphs appear in all copies, modifications, and
-# distributions. Contact The Office of Technology Licensing, UC Berkeley, 2150
-# Shattuck Avenue, Suite 510, Berkeley, CA 94720-1620, (510) 643-7201,
-# otl@berkeley.edu,
-# http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
-
-# IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
-# INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
-# THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN
-# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-# REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
-# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-# PURPOSE. THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED
-# HEREUNDER IS PROVIDED "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE
-# MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
-
 # general optimization params
 train_batch_size: 64
 val_batch_size: &val_batch_size 64
@@ -31,7 +9,7 @@ save_frequency: 10    # how often to save output (in epochs)
 vis_frequency: 10000  # how often to visualize filters (in epochs)
 log_frequency: 1      # how often to log output (in steps)
 
-# train / val split params 
+# train / val split params
 train_pct: 0.9              # percentage of the data to use for training vs validation
 total_pct: 1.0              # percentage of all the files to use
 eval_total_train_error: 0   # whether or not to evaluate the total training error on each validataion

--- a/cfg/train_dex-net_2.0.yaml
+++ b/cfg/train_dex-net_2.0.yaml
@@ -1,25 +1,3 @@
-# Copyright ©2017. The Regents of the University of California (Regents).
-# All Rights Reserved. Permission to use, copy, modify, and distribute this
-# software and its documentation for educational, research, and not-for-profit
-# purposes, without fee and without a signed licensing agreement, is hereby
-# granted, provided that the above copyright notice, this paragraph and the
-# following two paragraphs appear in all copies, modifications, and
-# distributions. Contact The Office of Technology Licensing, UC Berkeley, 2150
-# Shattuck Avenue, Suite 510, Berkeley, CA 94720-1620, (510) 643-7201,
-# otl@berkeley.edu,
-# http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
-
-# IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
-# INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
-# THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN
-# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-# REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
-# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-# PURPOSE. THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED
-# HEREUNDER IS PROVIDED "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE
-# MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
-
 # general optimization params
 train_batch_size: 64
 val_batch_size: &val_batch_size 64

--- a/cfg/train_dex-net_3.0.yaml
+++ b/cfg/train_dex-net_3.0.yaml
@@ -1,25 +1,3 @@
-# Copyright ©2017. The Regents of the University of California (Regents).
-# All Rights Reserved. Permission to use, copy, modify, and distribute this
-# software and its documentation for educational, research, and not-for-profit
-# purposes, without fee and without a signed licensing agreement, is hereby
-# granted, provided that the above copyright notice, this paragraph and the
-# following two paragraphs appear in all copies, modifications, and
-# distributions. Contact The Office of Technology Licensing, UC Berkeley, 2150
-# Shattuck Avenue, Suite 510, Berkeley, CA 94720-1620, (510) 643-7201,
-# otl@berkeley.edu,
-# http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
-
-# IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
-# INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
-# THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN
-# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-# REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
-# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-# PURPOSE. THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED
-# HEREUNDER IS PROVIDED "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE
-# MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
-
 # general optimization params
 train_batch_size: 64
 val_batch_size: &val_batch_size 64

--- a/cfg/train_dex-net_4.0_fc_pj.yaml
+++ b/cfg/train_dex-net_4.0_fc_pj.yaml
@@ -1,25 +1,3 @@
-# Copyright ©2017. The Regents of the University of California (Regents).
-# All Rights Reserved. Permission to use, copy, modify, and distribute this
-# software and its documentation for educational, research, and not-for-profit
-# purposes, without fee and without a signed licensing agreement, is hereby
-# granted, provided that the above copyright notice, this paragraph and the
-# following two paragraphs appear in all copies, modifications, and
-# distributions. Contact The Office of Technology Licensing, UC Berkeley, 2150
-# Shattuck Avenue, Suite 510, Berkeley, CA 94720-1620, (510) 643-7201,
-# otl@berkeley.edu,
-# http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
-
-# IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
-# INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
-# THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN
-# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-# REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
-# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-# PURPOSE. THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED
-# HEREUNDER IS PROVIDED "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE
-# MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
-
 # general optimization params
 train_batch_size: 64
 val_batch_size: &val_batch_size 64
@@ -31,7 +9,7 @@ save_frequency: 10    # how often to save output (in epochs)
 vis_frequency: 10000  # how often to visualize filters (in epochs)
 log_frequency: 1      # how often to log output (in steps)
 
-# train / val split params 
+# train / val split params
 train_pct: 0.8              # percentage of the data to use for training vs validation
 total_pct: 1.0              # percentage of all the files to use
 eval_total_train_error: 0   # whether or not to evaluate the total training error on each validataion

--- a/cfg/train_dex-net_4.0_fc_suction.yaml
+++ b/cfg/train_dex-net_4.0_fc_suction.yaml
@@ -1,25 +1,3 @@
-# Copyright ©2017. The Regents of the University of California (Regents).
-# All Rights Reserved. Permission to use, copy, modify, and distribute this
-# software and its documentation for educational, research, and not-for-profit
-# purposes, without fee and without a signed licensing agreement, is hereby
-# granted, provided that the above copyright notice, this paragraph and the
-# following two paragraphs appear in all copies, modifications, and
-# distributions. Contact The Office of Technology Licensing, UC Berkeley, 2150
-# Shattuck Avenue, Suite 510, Berkeley, CA 94720-1620, (510) 643-7201,
-# otl@berkeley.edu,
-# http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
-
-# IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
-# INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
-# THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN
-# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-# REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
-# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-# PURPOSE. THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED
-# HEREUNDER IS PROVIDED "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE
-# MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
-
 # general optimization params
 train_batch_size: 64
 val_batch_size: &val_batch_size 64
@@ -31,7 +9,7 @@ save_frequency: 10    # how often to save output (in epochs)
 vis_frequency: 10000  # how often to visualize filters (in epochs)
 log_frequency: 1      # how often to log output (in steps)
 
-# train / val split params 
+# train / val split params
 train_pct: 0.8              # percentage of the data to use for training vs validation
 total_pct: 1.0              # percentage of all the files to use
 eval_total_train_error: 0   # whether or not to evaluate the total training error on each validataion

--- a/cfg/train_dex-net_4.0_pj.yaml
+++ b/cfg/train_dex-net_4.0_pj.yaml
@@ -1,25 +1,3 @@
-# Copyright ©2017. The Regents of the University of California (Regents).
-# All Rights Reserved. Permission to use, copy, modify, and distribute this
-# software and its documentation for educational, research, and not-for-profit
-# purposes, without fee and without a signed licensing agreement, is hereby
-# granted, provided that the above copyright notice, this paragraph and the
-# following two paragraphs appear in all copies, modifications, and
-# distributions. Contact The Office of Technology Licensing, UC Berkeley, 2150
-# Shattuck Avenue, Suite 510, Berkeley, CA 94720-1620, (510) 643-7201,
-# otl@berkeley.edu,
-# http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
-
-# IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
-# INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
-# THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN
-# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-# REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
-# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-# PURPOSE. THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED
-# HEREUNDER IS PROVIDED "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE
-# MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
-
 # general optimization params
 train_batch_size: 64
 val_batch_size: &val_batch_size 64
@@ -31,7 +9,7 @@ save_frequency: 10    # how often to save output (in epochs)
 vis_frequency: 10000  # how often to visualize filters (in epochs)
 log_frequency: 1      # how often to log output (in steps)
 
-# train / val split params 
+# train / val split params
 train_pct: 0.8              # percentage of the data to use for training vs validation
 total_pct: 1.0              # percentage of all the files to use
 eval_total_train_error: 0   # whether or not to evaluate the total training error on each validataion

--- a/cfg/train_dex-net_4.0_suction.yaml
+++ b/cfg/train_dex-net_4.0_suction.yaml
@@ -1,25 +1,3 @@
-# Copyright ©2017. The Regents of the University of California (Regents).
-# All Rights Reserved. Permission to use, copy, modify, and distribute this
-# software and its documentation for educational, research, and not-for-profit
-# purposes, without fee and without a signed licensing agreement, is hereby
-# granted, provided that the above copyright notice, this paragraph and the
-# following two paragraphs appear in all copies, modifications, and
-# distributions. Contact The Office of Technology Licensing, UC Berkeley, 2150
-# Shattuck Avenue, Suite 510, Berkeley, CA 94720-1620, (510) 643-7201,
-# otl@berkeley.edu,
-# http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
-
-# IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
-# INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
-# THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN
-# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-# REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
-# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-# PURPOSE. THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED
-# HEREUNDER IS PROVIDED "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE
-# MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
-
 # general optimization params
 train_batch_size: 64
 val_batch_size: &val_batch_size 64
@@ -31,7 +9,7 @@ save_frequency: 10    # how often to save output (in epochs)
 vis_frequency: 10000  # how often to visualize filters (in epochs)
 log_frequency: 1      # how often to log output (in steps)
 
-# train / val split params 
+# train / val split params
 train_pct: 0.8              # percentage of the data to use for training vs validation
 total_pct: 1.0              # percentage of all the files to use
 eval_total_train_error: 0   # whether or not to evaluate the total training error on each validataion

--- a/cfg/train_example_pj.yaml
+++ b/cfg/train_example_pj.yaml
@@ -1,25 +1,3 @@
-# Copyright ©2017. The Regents of the University of California (Regents).
-# All Rights Reserved. Permission to use, copy, modify, and distribute this
-# software and its documentation for educational, research, and not-for-profit
-# purposes, without fee and without a signed licensing agreement, is hereby
-# granted, provided that the above copyright notice, this paragraph and the
-# following two paragraphs appear in all copies, modifications, and
-# distributions. Contact The Office of Technology Licensing, UC Berkeley, 2150
-# Shattuck Avenue, Suite 510, Berkeley, CA 94720-1620, (510) 643-7201,
-# otl@berkeley.edu,
-# http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
-
-# IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
-# INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
-# THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN
-# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-# REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
-# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-# PURPOSE. THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED
-# HEREUNDER IS PROVIDED "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE
-# MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
-
 # general optimization params
 train_batch_size: 64
 val_batch_size: &val_batch_size 64
@@ -31,7 +9,7 @@ save_frequency: 10    # how often to save output (in epochs)
 vis_frequency: 10000  # how often to visualize filters (in epochs)
 log_frequency: 1      # how often to log output (in steps)
 
-# train / val split params 
+# train / val split params
 train_pct: 0.9              # percentage of the data to use for training vs validation
 total_pct: 1.0              # percentage of all the files to use
 eval_total_train_error: 0   # whether or not to evaluate the total training error on each validataion

--- a/cfg/train_example_suction.yaml
+++ b/cfg/train_example_suction.yaml
@@ -1,25 +1,3 @@
-# Copyright ©2017. The Regents of the University of California (Regents).
-# All Rights Reserved. Permission to use, copy, modify, and distribute this
-# software and its documentation for educational, research, and not-for-profit
-# purposes, without fee and without a signed licensing agreement, is hereby
-# granted, provided that the above copyright notice, this paragraph and the
-# following two paragraphs appear in all copies, modifications, and
-# distributions. Contact The Office of Technology Licensing, UC Berkeley, 2150
-# Shattuck Avenue, Suite 510, Berkeley, CA 94720-1620, (510) 643-7201,
-# otl@berkeley.edu,
-# http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
-
-# IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
-# INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
-# THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN
-# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-# REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
-# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-# PURPOSE. THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED
-# HEREUNDER IS PROVIDED "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE
-# MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
-
 # general optimization params
 train_batch_size: 64
 val_batch_size: &val_batch_size 64
@@ -31,7 +9,7 @@ save_frequency: 10    # how often to save output (in epochs)
 vis_frequency: 10000  # how often to visualize filters (in epochs)
 log_frequency: 1      # how often to log output (in steps)
 
-# train / val split params 
+# train / val split params
 train_pct: 0.9              # percentage of the data to use for training vs validation
 total_pct: 1.0              # percentage of all the files to use
 eval_total_train_error: 0   # whether or not to evaluate the total training error on each validataion

--- a/cfg/train_fc.yaml
+++ b/cfg/train_fc.yaml
@@ -1,25 +1,3 @@
-# Copyright ©2017. The Regents of the University of California (Regents).
-# All Rights Reserved. Permission to use, copy, modify, and distribute this
-# software and its documentation for educational, research, and not-for-profit
-# purposes, without fee and without a signed licensing agreement, is hereby
-# granted, provided that the above copyright notice, this paragraph and the
-# following two paragraphs appear in all copies, modifications, and
-# distributions. Contact The Office of Technology Licensing, UC Berkeley, 2150
-# Shattuck Avenue, Suite 510, Berkeley, CA 94720-1620, (510) 643-7201,
-# otl@berkeley.edu,
-# http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
-
-# IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
-# INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
-# THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN
-# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-# REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
-# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-# PURPOSE. THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED
-# HEREUNDER IS PROVIDED "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE
-# MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
-
 # general optimization params
 train_batch_size: 64
 val_batch_size: &val_batch_size 64
@@ -31,7 +9,7 @@ save_frequency: 10    # how often to save output (in epochs)
 vis_frequency: 10000  # how often to visualize filters (in epochs)
 log_frequency: 1      # how often to log output (in steps)
 
-# train / val split params 
+# train / val split params
 train_pct: 0.8              # percentage of the data to use for training vs validation
 total_pct: 1.0              # percentage of all the files to use
 eval_total_train_error: 0   # whether or not to evaluate the total training error on each validataion


### PR DESCRIPTION
Removed license since it contained a unicode copyright character that was causing trouble in Python 3 during reading, and because it's not really needed for the configs anyways.