### PR TITLE
Updated requirements for matplotlib to be <=2.2.0

### DIFF
--- a/requirements/cpu_requirements.txt
+++ b/requirements/cpu_requirements.txt
@@ -4,7 +4,7 @@ visualization
 numpy
 opencv-python
 scipy
-matplotlib
+matplotlib<=2.2.0
 tensorflow<=1.15.0
 scikit-learn
 scikit-image

--- a/requirements/gpu_requirements.txt
+++ b/requirements/gpu_requirements.txt
@@ -4,7 +4,7 @@ visualization
 numpy
 opencv-python
 scipy
-matplotlib
+matplotlib<=2.2.0
 tensorflow-gpu<=1.15.0
 scikit-learn
 scikit-image

--- a/setup.py
+++ b/setup.py
@@ -138,7 +138,7 @@ class InstallCmd(install, object):
 
 requirements = [
     "autolab-core", "autolab-perception", "visualization", "numpy", "scipy",
-    "matplotlib", "opencv-python", "scikit-learn", "scikit-image", "psutil",
+    "matplotlib<=2.2.0", "opencv-python", "scikit-learn", "scikit-image", "psutil",
     "gputil"
 ]
 


### PR DESCRIPTION
The docker image currently can't build as the matplotlib version doesn't match for some libraries.