### PR TITLE
Ros docker

### DIFF
--- a/docker/ros/Dockerfile.ros
+++ b/docker/ros/Dockerfile.ros
@@ -1,0 +1,42 @@
+FROM ros:noetic-ros-core
+
+ARG cpu_or_gpu
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    software-properties-common \
+    build-essential \
+    curl \
+    libsm6 \
+    libxext6 \
+    libglib2.0-0 \
+    libxrender1 \
+    wget \
+    libpng-dev \
+    pkg-config \
+    libfreetype6-dev \
+    ros-noetic-cv-bridge \
+    freeglut3-dev \
+    unzip
+
+RUN add-apt-repository ppa:deadsnakes/ppa
+
+RUN apt-get update && apt-get -y install  \
+    python3.7 \
+    python3.7-dev \
+    python3-pip \
+    python3.7-tk
+
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.7 1
+RUN python3.7 -m pip install --no-cache-dir --upgrade setuptools pip wheel numpy netifaces pyglet pycryptodomex crypto
+ 
+RUN /bin/bash -c "mkdir -p /root/catkin_ws/src"
+ENV CATKIN_WS /root/catkin_ws
+
+WORKDIR $CATKIN_WS
+
+COPY [ "gqcnn/", "$CATKIN_WS/src/gqcnn/" ]
+
+RUN python3 -m pip install --no-cache-dir -r $CATKIN_WS/src/gqcnn/requirements/${cpu_or_gpu}_requirements.txt
+
+RUN /bin/bash -c "source /opt/ros/noetic/setup.bash \
+    && catkin_make install -DCMAKE_INSTALL_PREFIX=/opt/ros/noetic/"

--- a/docker/ros/config.env
+++ b/docker/ros/config.env
@@ -1,0 +1,6 @@
+export COMPOSE_PROJECT_NAME=berkeley_automation
+export HOST_IP=127.0.0.1
+export ROS_MASTER_URI=http://${HOST_IP}:11311
+export ROS_IP=${HOST_IP}
+export MODEL=GQCNN-4.0-PJ
+export cpu_or_gpu=cpu # or gpu

--- a/docker/ros/docker-compose.yml
+++ b/docker/ros/docker-compose.yml
@@ -1,0 +1,48 @@
+version: '3.4'
+
+services:
+  ros_master:
+    image: ros:kinetic-ros-core
+    network_mode: host
+    environment:
+      - ROS_MASTER_URI=${ROS_MASTER_URI}
+      - ROS_IP=${ROS_IP}
+    command: stdbuf -o L roscore
+
+  gqcnn:
+    image: gqcnn_${cpu_or_gpu}:latest
+    build:
+      args:
+        cpu_or_gpu: $cpu_or_gpu
+      context: ../../../
+      dockerfile: gqcnn/docker/ros/Dockerfile.ros
+    network_mode: host
+    environment:
+      - ROS_MASTER_URI=${ROS_MASTER_URI}
+      - ROS_IP=${ROS_IP}
+    volumes:
+      - ../../../gqcnn/:/root/catkin_ws/src/gqcnn/:ro
+    depends_on:
+      - ros_master
+    command: "bash -c 'source /root/catkin_ws/devel/setup.bash; roslaunch --wait gqcnn grasp_planning_service.launch model_name:=${MODEL};'"
+
+
+  #gqcnn_example:
+  #  image: gqcnn_${cpu_or_gpu}:latest
+  #  build:
+  #    args:
+  #      cpu_or_gpu: $cpu_or_gpu
+  #    context: ../../../
+  #    dockerfile: gqcnn/docker/ros/Dockerfile.ros
+  #  network_mode: host
+  #  environment:
+  #    - DISPLAY=$DISPLAY
+  #    - ROS_MASTER_URI=${ROS_MASTER_URI}
+  #    - ROS_IP=${ROS_IP}
+  #  volumes:
+  #    - ../../../gqcnn/:/root/catkin_ws/src/gqcnn/:ro
+  #    - /tmp/.X11-unix:/tmp/.X11-unix:ro
+  #    - $HOME/.Xauthority:/.Xauthority:ro
+  #  depends_on:
+  #    - gqcnn
+  #  command: "bash -c 'source /root/catkin_ws/devel/setup.bash; python3 /root/catkin_ws/src/gqcnn/examples/policy_ros.py'"

--- a/ros_nodes/grasp_planner_node.py
+++ b/ros_nodes/grasp_planner_node.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
 Copyright ©2017. The Regents of the University of California (Regents).

--- a/scripts/docker/run_docker_ros.sh
+++ b/scripts/docker/run_docker_ros.sh
@@ -31,12 +31,12 @@ function ctrl_c() {
 ctrl_c
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-echo $SCRIPT_DIR
+
 cd $SCRIPT_DIR
 cd ../../..
 source ./gqcnn/docker/ros/config.env
 
 xhost +local:docker
-#docker-compose -f gqcnn/docker/ros/docker-compose.yml build --no-cache --parellel
+#docker-compose -f gqcnn/docker/ros/docker-compose.yml build --no-cache --parallel
 docker-compose -f gqcnn/docker/ros/docker-compose.yml up
 xhost -local:docker

--- a/scripts/docker/run_docker_ros.sh
+++ b/scripts/docker/run_docker_ros.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# Copyright ©2017. The Regents of the University of California (Regents).
+# All Rights Reserved. Permission to use, copy, modify, and distribute this
+# software and its documentation for educational, research, and not-for-profit
+# purposes, without fee and without a signed licensing agreement, is hereby
+# granted, provided that the above copyright notice, this paragraph and the
+# following two paragraphs appear in all copies, modifications, and
+# distributions. Contact The Office of Technology Licensing, UC Berkeley, 2150
+# Shattuck Avenue, Suite 510, Berkeley, CA 94720-1620, (510) 643-7201,
+# otl@berkeley.edu,
+# http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+
+# IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+# INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+# THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN
+# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE. THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED
+# HEREUNDER IS PROVIDED "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE
+# MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+
+# Run the docker CPU image.
+
+function ctrl_c() {
+    #handle ctl+C
+    xhost -local:docker
+}
+ctrl_c
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+echo $SCRIPT_DIR
+cd $SCRIPT_DIR
+cd ../../..
+source ./gqcnn/docker/ros/config.env
+
+xhost +local:docker
+#docker-compose -f gqcnn/docker/ros/docker-compose.yml build --no-cache --parellel
+docker-compose -f gqcnn/docker/ros/docker-compose.yml up
+xhost -local:docker


### PR DESCRIPTION
Added a new dockerfile + docker-compose.yml to run the gqcnn service in ros. Using ros noetic, since it's easier to make python3 code  work in ros. 

Usage: install docker-compose [Install guide](https://docs.docker.com/compose/install/) and run the script. It will automatically build the image and run it. 

If you want to test it, comment out the service in the docker-compose yaml and rerun the script again. This will start the example_policy_ros.py with all default settings (downloaded models are required).